### PR TITLE
Only log HTTP status lines in Faraday calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Only log Faraday req/response status lines, not headers
+
 ## [0.3.0] - 2020-02-12
 
 ### Changed

--- a/lib/zaikio/hub.rb
+++ b/lib/zaikio/hub.rb
@@ -68,7 +68,7 @@ module Zaikio
         self.connection = Faraday.new(url: "#{configuration.host}/api/v1",
                                       ssl: { verify: configuration.environment != :test }) do |c|
           c.request     :json
-          c.response    :logger, configuration&.logger
+          c.response    :logger, configuration&.logger, headers: false
           c.use         JSONParser
           c.use         AuthorizationMiddleware
           c.use         BasicAuthMiddleware


### PR DESCRIPTION
Currently we log all of the headers on both sides, which looks like this:

```
I, [2021-02-17T08:20:57.049317 #54]  INFO -- request: GET https://hub.sandbox.zaikio.com/api/v1/person
I, [2021-02-17T08:20:57.049480 #54]  INFO -- request: User-Agent: "Faraday v1.3.0"
I, [2021-02-17T08:20:58.230897 #54]  INFO -- response: Status 200
I, [2021-02-17T08:20:58.231088 #54]  INFO -- response: server: "Cowboy"
date: "Wed, 17 Feb 2021 08:20:57 GMT"
connection: "keep-alive"
x-frame-options: "SAMEORIGIN"
x-xss-protection: "1; mode=block"
x-content-type-options: "nosniff"
x-download-options: "noopen"
x-permitted-cross-domain-policies: "none"
referrer-policy: "strict-origin-when-cross-origin"
content-type: "application/json; charset=utf-8"
etag: "W/\"6798887053c5b1aa813b106a88f9f3e9\""
cache-control: "max-age=0, private, must-revalidate"
x-request-id: "4bb196f0-7897-4656-884d-78c4810d010a"
x-runtime: "1.047974"
strict-transport-security: "max-age=63072000; includeSubDomains"
vary: "Origin"
transfer-encoding: "chunked"
via: "1.1 vegur"
```

After this change, we'll only log this:

```
I, [2021-02-17T08:20:57.049317 #54]  INFO -- request: GET https://hub.sandbox.zaikio.com/api/v1/person
I, [2021-02-17T08:20:58.230897 #54]  INFO -- response: Status 200
```