### PR TITLE
Include `id` property in `CurrentPerson#attributes` and `CurrentOrganization#attributes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2021-04-27
+
+* Include `id` property in `CurrentPerson#attributes` and `CurrentOrganization#attributes`
+
 ## [0.6.1] - 2020-04-12
 
 * Fixed that `each_page` works correctly with client instance
@@ -57,7 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added subscriptions (migration required)
 
-[Unreleased]: https://github.com/zaikio/zaikio-hub-ruby/compare/v0.6.1..HEAD
+[Unreleased]: https://github.com/zaikio/zaikio-hub-ruby/compare/v0.6.2..HEAD
+[0.6.2]: https://github.com/zaikio/zaikio-hub-ruby/compare/v0.6.1..v0.6.2
 [0.6.1]: https://github.com/zaikio/zaikio-hub-ruby/compare/v0.6.0..v0.6.1
 [0.6.0]: https://github.com/zaikio/zaikio-hub-ruby/compare/v0.5.0..v0.6.0
 [0.5.0]: https://github.com/zaikio/zaikio-hub-ruby/compare/v0.4.1..v0.5.0

--- a/lib/zaikio/hub/current_organization.rb
+++ b/lib/zaikio/hub/current_organization.rb
@@ -16,7 +16,7 @@ module Zaikio
       include_root_in_json :organization
 
       # Attributes
-      attributes :name, :slug, :logo_url, :connected, :subscription,
+      attributes :id, :name, :slug, :logo_url, :connected, :subscription,
                  :created_at, :updated_at, :country_code, :kinds,
                  :sections, :currency, :brand_color, :test_account_owner_id,
                  :granted_oauth_scopes, :requested_oauth_scopes,

--- a/lib/zaikio/hub/current_person.rb
+++ b/lib/zaikio/hub/current_person.rb
@@ -6,7 +6,7 @@ module Zaikio
       uri "person"
 
       # Attributes
-      attributes :updated_at, :created_at, :first_name, :name, :full_name, :email,
+      attributes :id, :updated_at, :created_at, :first_name, :name, :full_name, :email,
                  :pronoun, :locale, :country_code, :currency, :unit_system, :connected,
                  :test_account_owner_id, :time_zone, :email_confirmed,
                  :two_factor_authentication_enabled, :avatar_url, :subscription,

--- a/lib/zaikio/hub/version.rb
+++ b/lib/zaikio/hub/version.rb
@@ -1,5 +1,5 @@
 module Zaikio
   module Hub
-    VERSION = "0.6.1".freeze
+    VERSION = "0.6.2".freeze
   end
 end

--- a/test/zaikio/hub_test.rb
+++ b/test/zaikio/hub_test.rb
@@ -61,6 +61,7 @@ class Zaikio::Hub::Test < ActiveSupport::TestCase
                      Zaikio::Hub.current_token_data.audience
         person = Zaikio::Hub::CurrentPerson.new
         person.fetch
+        assert_equal "383663bc-149a-5b76-b50d-ee039046c12e", person.attributes["id"]
         assert_equal "Frank Gallikanokus", person.full_name
         assert_equal "Bounty Soap Inc.", person.admin_organizations.first.name
         assert_equal %w[directory.person.r warehouse.items.r], person.granted_oauth_scopes
@@ -132,6 +133,7 @@ class Zaikio::Hub::Test < ActiveSupport::TestCase
         assert_equal "My Machine", machine.name
         assert_equal "My Machine", organization.machines.all.last.name
         organization.fetch
+        assert_equal "b1475f65-236c-58b8-96e1-e1778b43beb7", organization.attributes["id"]
         assert_equal "Bounty Soap Inc.", organization.name
         assert_equal %w[directory.organization.r directory.machines.rw],
                      organization.granted_oauth_scopes


### PR DESCRIPTION
Without this change, the attributes looks like this:

```rb
  {
    nil => "b1475f65-236c-58b8-96e1-e1778b43beb7",
    "name" => "Bounty Soap Inc.",
    ...
  }
```

When we explicitly add :id to the attributes collection, it looks like this:

```rb
  {
    "id" => "b1475f65-236c-58b8-96e1-e1778b43beb7",
    "name" => "Bounty Soap Inc.",
    ...
  }
```

We're relying on the #attributes method in other places and so we need this property to be set.