### PR TITLE
Extract token data into Zaikio::Hub::TokenData class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Extract token data logic into its own `Zaikio::Hub::TokenData` class
+
+  This also exposes the `sub` attribute of the token as `TokenData#subject`.
+
 ## [0.10.0] - 2022-08-15
 
 * Update `zaikio-client-helpers` and reuse logic to use `Zaikio::Client.with_token`

--- a/lib/zaikio/hub.rb
+++ b/lib/zaikio/hub.rb
@@ -27,6 +27,7 @@ require "zaikio/hub/connection"
 require "zaikio/hub/app"
 require "zaikio/hub/subscription"
 require "zaikio/hub/test_account"
+require "zaikio/hub/token_data"
 
 module Zaikio
   module Hub
@@ -73,15 +74,7 @@ module Zaikio
       end
 
       def create_token_data(payload)
-        subjects = payload["sub"].split(">")
-
-        OpenStruct.new(
-          audience: payload["aud"].first,
-          on_behalf_of_id: subjects.first.split("/").last,
-          subject_id: subjects.last.split("/").last,
-          subject_type: subjects.last.split("/").first,
-          scopes: payload["scope"]
-        )
+        TokenData.from(payload)
       end
     end
   end

--- a/lib/zaikio/hub/token_data.rb
+++ b/lib/zaikio/hub/token_data.rb
@@ -1,0 +1,51 @@
+module Zaikio
+  module Hub
+    class TokenData
+      attr_reader :audience, :on_behalf_of, :subject, :scopes
+
+      def self.from(payload)
+        subjects = payload["sub"].split(">")
+
+        new(
+          audience: payload["aud"].first,
+          on_behalf_of: subjects.first,
+          subject: subjects.last,
+          scopes: payload["scope"]
+        )
+      end
+
+      def initialize(audience:, on_behalf_of:, subject:, scopes:)
+        @audience = audience
+        @on_behalf_of = on_behalf_of
+        @subject = subject
+        @scopes = scopes
+      end
+
+      def on_behalf_of_type
+        @on_behalf_of_type ||= type_for(:on_behalf_of)
+      end
+
+      def on_behalf_of_id
+        @on_behalf_of_id ||= id_for(:on_behalf_of)
+      end
+
+      def subject_type
+        @subject_type ||= type_for(:subject)
+      end
+
+      def subject_id
+        @subject_id ||= id_for(:subject)
+      end
+
+      private
+
+      def type_for(key)
+        public_send(key).split("/").first
+      end
+
+      def id_for(key)
+        public_send(key).split("/").last
+      end
+    end
+  end
+end

--- a/test/zaikio/hub_test.rb
+++ b/test/zaikio/hub_test.rb
@@ -109,6 +109,13 @@ class Zaikio::Hub::Test < ActiveSupport::TestCase
                          end
         assert_equal "383663bc-149a-5b76-b50d-ee039046c12e",
                      Zaikio::Hub.current_token_data.subject_id
+        assert_equal "Person/383663bc-149a-5b76-b50d-ee039046c12e",
+                     Zaikio::Hub.current_token_data.subject
+        assert_equal "Person", Zaikio::Hub.current_token_data.subject_type
+        assert_equal "Person/383663bc-149a-5b76-b50d-ee039046c12e",
+                     Zaikio::Hub.current_token_data.on_behalf_of
+        assert_equal "383663bc-149a-5b76-b50d-ee039046c12e",
+                     Zaikio::Hub.current_token_data.on_behalf_of_id
       end
     end
   end


### PR DESCRIPTION
This also exposes the `sub` attribute of the token as `#subject`.

This will be useful in the Warehouse, see https://github.com/zaikio/zai-warehouse/pull/1936#discussion_r951618915