### PR TITLE
Add subscription_url attribute to Suscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Added `subscription_url` attribute in `Subscription`
+
 ## [0.11.0] - 2022-08-30
 
 * Extract token data logic into its own `Zaikio::Hub::TokenData` class
   This also exposes the `sub` attribute of the token as `TokenData#subject`.
 * Support newer versions of `jwt` and `spyke`
-* Added `subscription_url` attribute in `Subscription`
 
 ## [0.10.0] - 2022-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Extract token data logic into its own `Zaikio::Hub::TokenData` class
   This also exposes the `sub` attribute of the token as `TokenData#subject`.
 * Support newer versions of `jwt` and `spyke`
+* Added `subscription_url` attribute in `Subscription`
 
 ## [0.10.0] - 2022-08-15
 

--- a/lib/zaikio/hub/subscription.rb
+++ b/lib/zaikio/hub/subscription.rb
@@ -9,7 +9,7 @@ module Zaikio
       attributes :updated_at, :created_at, :subscriber_type, :subscriber_id,
                  :status, :app_name, :activated_at, :last_billed_at,
                  :last_paid_at, :trial_ended_at, :plan, :plan_name, :preceding_plan,
-                 :changed_plan_at, :usages_in_current_billing_period
+                 :changed_plan_at, :subscripton_url, :usages_in_current_billing_period
 
       def initialize(attributes = {})
         if attributes["subscriber_id"]


### PR DESCRIPTION
Add subscription_url as part of Subscription's attribute. (attribute is available once Hub is newly deployed).